### PR TITLE
Add deployment to AWS

### DIFF
--- a/Buildfile
+++ b/Buildfile
@@ -1,0 +1,1 @@
+build: mvn -DskipTests clean package

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: java -Xmx500m -jar target/cw-0.0.1-SNAPSHOT.jar

--- a/system.properties
+++ b/system.properties
@@ -1,1 +1,0 @@
-java.runtime.version=11


### PR DESCRIPTION
Add Buildfile as AWS needs it to build app using maven and Procfile which aws needs to start app(important to set heap size to 500m because it is required by Spark), remove the system.properties file as it was needed for Heroku.